### PR TITLE
Convert launcher screens to Compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     implementation     'androidx.activity:activity-compose:1.10.1'
     implementation     'androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1'
     implementation     'androidx.compose.runtime:runtime-livedata'
+    implementation     'androidx.navigation:navigation-compose:2.9.0'
 
     // Terceros
     implementation 'com.github.mveroukis:storage-chooser:2.0.4.4a'

--- a/app/src/main/java/com/kyagamy/step/ui/SplashScreen.kt
+++ b/app/src/main/java/com/kyagamy/step/ui/SplashScreen.kt
@@ -1,0 +1,19 @@
+package com.kyagamy.step.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SplashScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/app/src/main/java/com/kyagamy/step/ui/StartScreen.kt
+++ b/app/src/main/java/com/kyagamy/step/ui/StartScreen.kt
@@ -1,0 +1,130 @@
+package com.kyagamy.step.ui
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.codekidlabs.storagechooser.StorageChooser
+import com.kyagamy.step.R
+import com.kyagamy.step.viewmodels.StartViewModel
+import com.kyagamy.step.views.MainActivity
+import com.kyagamy.step.views.DragStepActivity
+import com.kyagamy.step.views.LoadingSongActivity
+import com.kyagamy.step.views.InstallFilesActivity
+import com.kyagamy.step.ui.EvaluationActivity
+
+@Composable
+fun StartScreen(viewModel: StartViewModel, onNavigate: (Class<*>) -> Unit) {
+    val context = LocalContext.current
+    val activity = context as Activity
+    val permissions = remember {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            arrayOf(Manifest.permission.MANAGE_EXTERNAL_STORAGE)
+        } else {
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        }
+    }
+
+    var showRationale by remember { mutableStateOf(false) }
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { result ->
+        val granted = result.all { it.value }
+        viewModel.setPermissionsResult(granted)
+        if (!granted) {
+            val permanentlyDenied = permissions.all { !activity.shouldShowRequestPermissionRationale(it) }
+            if (permanentlyDenied) {
+                showRationale = true
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        launcher.launch(permissions)
+    }
+
+    if (showRationale) {
+        AlertDialog(
+            onDismissRequest = { showRationale = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val intent = Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.fromParts("package", context.packageName, null)
+                    )
+                    context.startActivity(intent)
+                    showRationale = false
+                }) { Text(text = "Open Settings") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRationale = false }) { Text("Cancel") }
+            },
+            title = { Text(text = "Permission required") },
+            text = { Text("Storage permission is required for StepDroid") }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Button(onClick = { onNavigate(MainActivity::class.java) }) {
+            Text("Start")
+        }
+        Button(onClick = { onNavigate(DragStepActivity::class.java) }) {
+            Text("Drag System")
+        }
+        Button(onClick = { onNavigate(LoadingSongActivity::class.java) }) {
+            Text("Reload Songs")
+        }
+        Button(onClick = { onNavigate(InstallFilesActivity::class.java) }) {
+            Text("DS")
+        }
+        Button(onClick = { onNavigate(EvaluationActivity::class.java) }) {
+            Text("Evaluation")
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (!viewModel.isBasePathSet()) {
+            showStorageChooser(activity) { path ->
+                viewModel.saveBasePath(path)
+                onNavigate(LoadingSongActivity::class.java)
+            }
+        }
+    }
+}
+
+private fun showStorageChooser(activity: Activity, onPath: (String) -> Unit) {
+    val chooser = StorageChooser.Builder()
+        .withActivity(activity)
+        .withFragmentManager(activity.fragmentManager)
+        .setDialogTitle("Choose Destination Folder")
+        .withMemoryBar(true)
+        .build()
+    chooser.show()
+    chooser.setOnSelectListener { path -> onPath(path) }
+}

--- a/app/src/main/java/com/kyagamy/step/viewmodels/StartViewModel.kt
+++ b/app/src/main/java/com/kyagamy/step/viewmodels/StartViewModel.kt
@@ -1,0 +1,32 @@
+package com.kyagamy.step.viewmodels
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import com.kyagamy.step.R
+
+class StartViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val _permissionsGranted = MutableStateFlow(false)
+    val permissionsGranted: StateFlow<Boolean> = _permissionsGranted.asStateFlow()
+
+    fun setPermissionsResult(granted: Boolean) {
+        _permissionsGranted.value = granted
+    }
+
+    fun isBasePathSet(): Boolean {
+        val ctx = getApplication<Application>()
+        val prefs = ctx.getSharedPreferences("pref", Context.MODE_PRIVATE)
+        val value = prefs.getString(ctx.getString(R.string.base_path), null)
+        return value != null
+    }
+
+    fun saveBasePath(path: String) {
+        val ctx = getApplication<Application>()
+        val prefs = ctx.getSharedPreferences("pref", Context.MODE_PRIVATE)
+        prefs.edit().putString(ctx.getString(R.string.base_path), path).apply()
+    }
+}

--- a/app/src/main/java/com/kyagamy/step/views/SplashActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/SplashActivity.kt
@@ -1,17 +1,36 @@
 package com.kyagamy.step.views
 
+import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import com.kyagamy.step.R
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.kyagamy.step.ui.SplashScreen
+import com.kyagamy.step.ui.ui.theme.StepDroidTheme
+import kotlinx.coroutines.delay
 
-
-class SplashActivity : AppCompatActivity() {
-
+class SplashActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_splash)
-
-
+        setContent {
+            StepDroidTheme {
+                SplashContent { navigateToStart() }
+            }
+        }
     }
 
+    private fun navigateToStart() {
+        startActivity(Intent(this, StartActivity::class.java))
+        finish()
+    }
+}
+
+@Composable
+private fun SplashContent(onTimeout: () -> Unit) {
+    SplashScreen()
+    LaunchedEffect(Unit) {
+        delay(800)
+        onTimeout()
+    }
 }

--- a/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
@@ -1,123 +1,50 @@
 package com.kyagamy.step.views
 
-import android.Manifest
-import android.content.Context
 import android.content.Intent
-import android.net.Uri
-import android.os.Build
 import android.os.Bundle
-import android.os.Environment
-import android.provider.Settings
-import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.lifecycleScope
-import com.codekidlabs.storagechooser.StorageChooser
-import com.gun0912.tedpermission.PermissionListener
-import com.gun0912.tedpermission.normal.TedPermission
-import com.kyagamy.step.BuildConfig
-import com.kyagamy.step.R
-import com.kyagamy.step.databinding.ActivityStartBinding
-import com.kyagamy.step.ui.EvaluationActivity
-import kotlinx.coroutines.launch
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.kyagamy.step.ui.SplashScreen
+import com.kyagamy.step.ui.StartScreen
+import com.kyagamy.step.ui.ui.theme.StepDroidTheme
+import com.kyagamy.step.viewmodels.StartViewModel
+import kotlinx.coroutines.delay
 
-class StartActivity : AppCompatActivity() {
+class StartActivity : ComponentActivity() {
 
-    private lateinit var binding: ActivityStartBinding
+    private val viewModel: StartViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityStartBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        setupButtons()
-        checkPermissions()
-        validateRoute()
-    }
-
-    private fun setupButtons() {
-        with(binding) {
-            buttonStart.setOnClickListener { navigateTo(MainActivity::class.java) }
-            dragStartButton.setOnClickListener { navigateTo(DragStepActivity::class.java) }
-            reloadSings.setOnClickListener { navigateTo(LoadingSongActivity::class.java) }
-            buttonDS.setOnClickListener { navigateTo(InstallFilesActivity::class.java) }
-            evaluation.setOnClickListener { navigateTo(EvaluationActivity::class.java) }
-        }
-    }
-
-    private fun navigateTo(destination: Class<*>) {
-        val intent = Intent(this, destination)
-        startActivity(intent)
-    }
-
-
-    private fun checkPermissions() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Para Android 11 (API 30) y superior
-            if (!Environment.isExternalStorageManager()) {
-                // El permiso MANAGE_EXTERNAL_STORAGE no está concedido, solicitar...
-                val uri = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
-                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri)
-                startActivity(intent) // Considera usar un ActivityResultLauncher para manejar el resultado
-            } else {
-                // Permiso concedido, continuar con la operación
-                showToast("Permission Granted")
-            }
-        } else {
-            // Para Android 10 (API 29) y versiones anteriores
-            val permissionListener = object : PermissionListener {
-                override fun onPermissionGranted() {
-                    showToast("Permission Granted")
-                }
-
-                override fun onPermissionDenied(deniedPermissions: List<String>) {
-                    showToast("Permission Denied\n$deniedPermissions")
+        setContent {
+            StepDroidTheme {
+                val navController = rememberNavController()
+                NavHost(navController, startDestination = "splash") {
+                    composable("splash") {
+                        SplashScreenWithDelay { navController.navigate("home") { popUpTo("splash") { inclusive = true } } }
+                    }
+                    composable("home") {
+                        val ctx = LocalContext.current
+                        StartScreen(viewModel) { dest -> ctx.startActivity(Intent(ctx, dest)) }
+                    }
                 }
             }
-
-            TedPermission.create()
-                .setPermissionListener(permissionListener)
-                .setDeniedMessage("If you reject permission, you cannot use this service\n\nPlease turn on permissions at [Settings] > [Permissions]")
-                .setPermissions(
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    Manifest.permission.READ_EXTERNAL_STORAGE
-                )
-                .check()
         }
     }
+}
 
-    private fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
-    }
-
-    private fun validateRoute() {
-        val sharedPref = getSharedPreferences("pref", Context.MODE_PRIVATE)
-        val basePath = sharedPref.getString(getString(R.string.base_path), "noPath")
-        if (basePath == "noPath") {
-            showStorageChooser()
-        }
-    }
-
-    private fun showStorageChooser() {
-        val chooser = StorageChooser.Builder()
-            .withActivity(this)
-            .withFragmentManager(fragmentManager) // Make sure you are using the correct fragmentManager here
-            .setDialogTitle("Choose Destination Folder")
-            .withMemoryBar(true)
-            .build()
-
-        chooser.show()
-        chooser.setOnSelectListener { path ->
-            lifecycleScope.launch {
-                saveBasePath(path)
-                navigateTo(LoadingSongActivity::class.java)
-            }
-        }
-    }
-
-    private fun saveBasePath(path: String) {
-        val sharedPref = getSharedPreferences("pref", Context.MODE_PRIVATE)
-        with(sharedPref.edit()) {
-            putString(getString(R.string.base_path), path)
-            apply()
-        }
+@Composable
+private fun SplashScreenWithDelay(onFinish: () -> Unit) {
+    SplashScreen()
+    LaunchedEffect(Unit) {
+        delay(500)
+        onFinish()
     }
 }


### PR DESCRIPTION
## Summary
- move StartActivity and SplashActivity to Jetpack Compose
- add navigation‑compose dependency
- introduce StartViewModel for permission and path state
- create `StartScreen` and `SplashScreen` composables

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad1ebed18832fa3324af782d5aad3