### PR TITLE
Add flexible DAO queries and use Int level

### DIFF
--- a/app/src/main/java/com/kyagamy/step/adapters/LevelAdapter.kt
+++ b/app/src/main/java/com/kyagamy/step/adapters/LevelAdapter.kt
@@ -47,7 +47,7 @@ class LevelAdapter internal constructor(
 
     override fun onBindViewHolder(holder: songViewHolder, position: Int) {
         val current = levels[position]
-        holder.level.text = if (current.METER.length >= 2) current.METER else ("0" + current.METER)
+        holder.level.text = if (current.METER >= 10) current.METER.toString() else ("0" + current.METER)
 
         val anim = AnimationUtils.loadAnimation(
             context,

--- a/app/src/main/java/com/kyagamy/step/adapters/LevelAdapterPreview.kt
+++ b/app/src/main/java/com/kyagamy/step/adapters/LevelAdapterPreview.kt
@@ -45,7 +45,7 @@ class LevelAdapterPreview internal constructor(
 
     override fun onBindViewHolder(holder: songViewHolder, position: Int) {
         val current = levels[position]
-        holder.level.text = if (current.METER.length >= 2) current.METER else ("0" + current.METER)
+        holder.level.text = if (current.METER >= 10) current.METER.toString() else ("0" + current.METER)
 
         //fuente
         val custom_font = Typeface.createFromAsset(context.assets, "fonts/karnivol.ttf")

--- a/app/src/main/java/com/kyagamy/step/common/step/Parsers/FileSSC.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/Parsers/FileSSC.kt
@@ -73,11 +73,12 @@ class FileSSC(override var pathFile: String, override var indexStep: Int) : Step
             } else {
                 if (indexLevel != -1) {//means not LEVEL TAG
                     if (auxIndexToSaveORM != indexLevel) {//when change level
+                        val meter = levelMetaData["METER"]?.toIntOrNull() ?: 0
                         listLevels.add(
                             Level(
                                 0,
                                 auxIndexToSaveORM,
-                                levelMetaData["METER"] ?: "",
+                                meter,
                                 levelMetaData["CREDIT"] ?: "",
                                 levelMetaData["STEPSTYPE"] ?: "",
                                 levelMetaData["DESCRIPTION"] ?: "",
@@ -98,11 +99,12 @@ class FileSSC(override var pathFile: String, override var indexStep: Int) : Step
             }
         }
         try {//try to add last level
+            val meter = levelMetaData["METER"]?.toIntOrNull() ?: 0
             listLevels.add(
                 Level(
                     0,
                     auxIndexToSaveORM,
-                    levelMetaData["METER"] ?: "",
+                    meter,
                     levelMetaData["CREDIT"] ?: "",
                     levelMetaData["STEPSTYPE"] ?: "",
                     levelMetaData["DESCRIPTION"] ?: "",

--- a/app/src/main/java/com/kyagamy/step/game/newplayer/EvaluationActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/game/newplayer/EvaluationActivity.kt
@@ -55,7 +55,7 @@ class EvaluationActivity : FullScreenActivity() {
 //        levelRecycl
         //ADAPTERS
         val levelAdapter = LevelAdapter(this)
-        var lvl = Level(1, 1, "22", "me", "pump-single", "asdasd", "name", 1, null)
+        var lvl = Level(1, 1, 22, "me", "pump-single", "asdasd", "name", 1, null)
 
         var level = listOf(lvl)
         levelAdapter.setLevels(level)

--- a/app/src/main/java/com/kyagamy/step/room/SDDatabase.kt
+++ b/app/src/main/java/com/kyagamy/step/room/SDDatabase.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 
 @Database(
     entities = [Song::class, Category::class, Level::class],
-    version = 13    ,
+    version = 14    ,
     exportSchema = false
 )
  abstract class SDDatabase : RoomDatabase() {

--- a/app/src/main/java/com/kyagamy/step/room/entities/CategoryDao.kt
+++ b/app/src/main/java/com/kyagamy/step/room/entities/CategoryDao.kt
@@ -26,6 +26,9 @@ interface CategoryDao {
     @Query(value = "select  * from Category where name=:arg0")
     fun getByName(arg0:String):Category
 
+    @Query("SELECT * FROM Category WHERE name LIKE '%' || :filter || '%' ORDER BY name ASC")
+    fun searchByName(filter: String): LiveData<List<Category>>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(cate: Category)
 

--- a/app/src/main/java/com/kyagamy/step/room/entities/Level.kt
+++ b/app/src/main/java/com/kyagamy/step/room/entities/Level.kt
@@ -12,7 +12,7 @@ class Level (
     @PrimaryKey(autoGenerate = true)
     val id:Int,
     val index:Int,
-    val METER:String,
+    val METER:Int,
     val CREDIT:String,
     val STEPSTYPE:String,
     val DESCRIPTION:String,

--- a/app/src/main/java/com/kyagamy/step/room/entities/LevelDao.kt
+++ b/app/src/main/java/com/kyagamy/step/room/entities/LevelDao.kt
@@ -8,7 +8,7 @@ interface LevelDao {
     @Query("SELECT * FROM Level order by STEPSTYPE asc, `index` desc")
     fun getAll(): LiveData<List<Level>>
 
-    @Query("SELECT * FROM Level where song_id = :songId order by STEPSTYPE desc, `index` asc")
+    @Query("SELECT * FROM Level where song_fkid = :songId order by STEPSTYPE desc, `index` asc")
     fun getLevelBySongId(songId: Int ): LiveData<List<Level>>
 
     @Query("delete from Level")
@@ -16,4 +16,21 @@ interface LevelDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(cate: Level)
+
+    @Query(
+        """
+        SELECT * FROM Level
+        WHERE (:songId IS NULL OR song_fkid = :songId)
+          AND (:stepType IS NULL OR STEPSTYPE LIKE '%' || :stepType || '%')
+          AND (:minMeter IS NULL OR METER >= :minMeter)
+          AND (:maxMeter IS NULL OR METER <= :maxMeter)
+        ORDER BY STEPSTYPE ASC, `index` DESC
+        """
+    )
+    fun queryLevels(
+        songId: Int?,
+        stepType: String?,
+        minMeter: Int?,
+        maxMeter: Int?
+    ): LiveData<List<Level>>
 }

--- a/app/src/main/java/com/kyagamy/step/room/entities/SongDao.kt
+++ b/app/src/main/java/com/kyagamy/step/room/entities/SongDao.kt
@@ -50,4 +50,29 @@ interface SongDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(Song: Song)
+
+    @Query(
+        """
+        SELECT DISTINCT s.* FROM Song s
+        INNER JOIN Level l ON s.song_id = l.song_fkid
+        WHERE (:category IS NULL OR s.catecatecate LIKE '%' || :category || '%')
+          AND (:stepType IS NULL OR l.STEPSTYPE LIKE '%' || :stepType || '%')
+          AND (:minLevel IS NULL OR l.METER >= :minLevel)
+          AND (:maxLevel IS NULL OR l.METER <= :maxLevel)
+          AND (:title IS NULL OR s.TITLE LIKE '%' || :title || '%')
+          AND (:artist IS NULL OR s.ARTIST LIKE '%' || :artist || '%')
+          AND (:bpm IS NULL OR s.DISPLAYBPM LIKE '%' || :bpm || '%')
+        ORDER BY RANDOM() LIMIT :limit
+        """
+    )
+    suspend fun getRandomSongs(
+        category: String?,
+        stepType: String?,
+        minLevel: Int?,
+        maxLevel: Int?,
+        title: String?,
+        artist: String?,
+        bpm: String?,
+        limit: Int
+    ): List<Song>
 }

--- a/app/src/main/java/com/kyagamy/step/room/repos/CategoryRepository.kt
+++ b/app/src/main/java/com/kyagamy/step/room/repos/CategoryRepository.kt
@@ -16,6 +16,10 @@ class CategoryRepository(private val cateDao: CategoryDao) {
         cateDao.insert(cate)
     }
 
+    fun searchByName(filter: String): LiveData<List<Category>> {
+        return cateDao.searchByName(filter)
+    }
+
     suspend fun deleteAll() {
         cateDao.deleteAll()
     }

--- a/app/src/main/java/com/kyagamy/step/room/repos/LevelRepository.kt
+++ b/app/src/main/java/com/kyagamy/step/room/repos/LevelRepository.kt
@@ -19,4 +19,13 @@ class LevelRepository(private val levelDao: LevelDao) {
     suspend fun insert(level: Level) {
         levelDao.insert(level)
     }
+
+    fun queryLevels(
+        songId: Int?,
+        stepType: String?,
+        minMeter: Int?,
+        maxMeter: Int?
+    ): LiveData<List<Level>> {
+        return levelDao.queryLevels(songId, stepType, minMeter, maxMeter)
+    }
 }

--- a/app/src/main/java/com/kyagamy/step/room/repos/SongRepository.kt
+++ b/app/src/main/java/com/kyagamy/step/room/repos/SongRepository.kt
@@ -44,4 +44,26 @@ class SongRepository(private val songDao: SongDao) {
     suspend fun insert(song: Song) {
          songDao.insert(song)
     }
+
+    suspend fun getRandomSongs(
+        category: String?,
+        stepType: String?,
+        minLevel: Int?,
+        maxLevel: Int?,
+        title: String?,
+        artist: String?,
+        bpm: String?,
+        limit: Int
+    ): List<Song> {
+        return songDao.getRandomSongs(
+            category,
+            stepType,
+            minLevel,
+            maxLevel,
+            title,
+            artist,
+            bpm,
+            limit
+        )
+    }
 }

--- a/app/src/main/java/com/kyagamy/step/viewmodels/CategoryViewModel.kt
+++ b/app/src/main/java/com/kyagamy/step/viewmodels/CategoryViewModel.kt
@@ -29,4 +29,8 @@ class CategoryViewModel(application: Application) : AndroidViewModel(application
         repository.deleteAll()
     }
 
+    fun searchByName(filter: String): LiveData<List<Category>> {
+        return repository.searchByName(filter)
+    }
+
 }

--- a/app/src/main/java/com/kyagamy/step/viewmodels/LevelViewModel.kt
+++ b/app/src/main/java/com/kyagamy/step/viewmodels/LevelViewModel.kt
@@ -40,5 +40,14 @@ class LevelViewModel(application: Application) : AndroidViewModel(application) {
         return  repository.getLevelBySongId(songId)
     }
 
+    fun queryLevels(
+        songId: Int?,
+        stepType: String?,
+        minMeter: Int?,
+        maxMeter: Int?
+    ): LiveData<List<Level>> {
+        return repository.queryLevels(songId, stepType, minMeter, maxMeter)
+    }
+
 
 }

--- a/app/src/main/java/com/kyagamy/step/viewmodels/SongViewModel.kt
+++ b/app/src/main/java/com/kyagamy/step/viewmodels/SongViewModel.kt
@@ -63,4 +63,26 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
         return repository.idSong(id)
     }
 
+    suspend fun randomSongs(
+        category: String?,
+        stepType: String?,
+        minLevel: Int?,
+        maxLevel: Int?,
+        title: String?,
+        artist: String?,
+        bpm: String?,
+        limit: Int
+    ): List<Song> {
+        return repository.getRandomSongs(
+            category,
+            stepType,
+            minLevel,
+            maxLevel,
+            title,
+            artist,
+            bpm,
+            limit
+        )
+    }
+
 }

--- a/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
@@ -337,11 +337,7 @@ fun StartScreen(viewModel: StartViewModel) {
                 // Filtrar canciones que tengan al menos un nivel > 19
                 val songIdsWithHighLevel = allLevels
                     .filter { level ->
-                        try {
-                            level.METER.toInt() > 19
-                        } catch (e: NumberFormatException) {
-                            false
-                        }
+                        level.METER > 19
                     }
                     .map { it.song_fkid }
                     .toSet()


### PR DESCRIPTION
## Summary
- make `Level.METER` an `Int`
- allow complex song queries and category search
- add random song query with multiple filters
- expose new DAO functions in repositories and view models
- bump DB version to force migration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686751c6ee30832fbd7baf6f87a9f125