### PR TITLE
Implement GL test player

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,7 @@
             android:hardwareAccelerated="true"
             android:keepScreenOn="true"
             android:screenOrientation="fullSensor" />
+        <activity android:name=".views.TestGLPlayerActivity" />
 
         <meta-data
             android:name="preloaded_fonts"

--- a/app/src/main/java/com/kyagamy/step/engine/ArrowSpriteRenderer.kt
+++ b/app/src/main/java/com/kyagamy/step/engine/ArrowSpriteRenderer.kt
@@ -1,0 +1,29 @@
+package com.kyagamy.step.engine
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.graphics.Rect
+import androidx.annotation.DrawableRes
+
+/**
+ * Simple wrapper around [SpriteGLRenderer] that loads a single arrow texture
+ * and exposes it as an [android.opengl.GLSurfaceView.Renderer].
+ */
+class ArrowSpriteRenderer(context: Context, @DrawableRes resId: Int) : ISpriteRenderer {
+    private val renderer: SpriteGLRenderer
+
+    init {
+        val bitmap = BitmapFactory.decodeResource(context.resources, resId)
+        renderer = SpriteGLRenderer(context, arrayOf(bitmap))
+    }
+
+    fun getGLRenderer(): android.opengl.GLSurfaceView.Renderer = renderer
+
+    override fun draw(rect: Rect) {
+        renderer.draw(rect)
+    }
+
+    override fun update() {
+        renderer.update()
+    }
+}

--- a/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/StartActivity.kt
@@ -52,6 +52,7 @@ import com.kyagamy.step.viewmodels.StartViewModel
 import com.kyagamy.step.viewmodels.SongViewModel
 import com.kyagamy.step.viewmodels.LevelViewModel
 import com.kyagamy.step.ui.ui.theme.StepDroidTheme
+import com.kyagamy.step.views.TestGLPlayerActivity
 import kotlinx.coroutines.launch
 import kotlin.random.Random
 
@@ -384,6 +385,10 @@ fun StartScreen(viewModel: StartViewModel) {
         Spacer(Modifier.height(8.dp))
         Button(onClick = { context.startActivity(Intent(context, AddMediaFromLinkActivity::class.java)) }) {
             Text("DS")
+        }
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { context.startActivity(Intent(context, TestGLPlayerActivity::class.java)) }) {
+            Text("Test GL Player")
         }
         Spacer(Modifier.height(8.dp))
         Button(onClick = { context.startActivity(Intent(context, EvaluationActivity::class.java)) }) {

--- a/app/src/main/java/com/kyagamy/step/views/TestGLPlayerActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/TestGLPlayerActivity.kt
@@ -1,0 +1,19 @@
+package com.kyagamy.step.views
+
+import android.app.Activity
+import android.os.Bundle
+import com.kyagamy.step.R
+import com.kyagamy.step.engine.ArrowSpriteRenderer
+import com.kyagamy.step.engine.OpenGLSpriteView
+
+class TestGLPlayerActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_test_gl_player)
+
+        val glView = findViewById<OpenGLSpriteView>(R.id.openGLSpriteView)
+        val renderer = ArrowSpriteRenderer(this, R.drawable.blue_arrow_l)
+        glView.setRenderer(renderer.getGLRenderer())
+        glView.renderMode = android.opengl.GLSurfaceView.RENDERMODE_CONTINUOUSLY
+    }
+}

--- a/app/src/main/java/com/kyagamy/step/views/gameplayactivity/GamePlayActivity.kt
+++ b/app/src/main/java/com/kyagamy/step/views/gameplayactivity/GamePlayActivity.kt
@@ -42,7 +42,6 @@ import java.io.FileInputStream
 import java.util.*
 import kotlin.collections.ArrayList
 import com.kyagamy.step.databinding.ActivityPlayerbgaBinding
-import com.kyagamy.step.engine.TestSongRenderer
 
 
 class GamePlayActivity : Activity() {
@@ -58,7 +57,6 @@ class GamePlayActivity : Activity() {
 
     var gamePlayError = false
     private val arrowsPosition2: ArrayList<Rect> = ArrayList()
-    private var testSongRenderer: TestSongRenderer? = null
 
     private var stepInfo: List<Int> = listOf(
         R.drawable.selector_down_left,
@@ -84,12 +82,7 @@ class GamePlayActivity : Activity() {
             WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
         )
 
-        // Inicializar OpenGL renderer de prueba
-        testSongRenderer = TestSongRenderer(this)
-        binding.openGLSpriteView?.let { glView ->
-            glView.setRenderer(testSongRenderer!! as android.opengl.GLSurfaceView.Renderer)
-            glView.renderMode = android.opengl.GLSurfaceView.RENDERMODE_CONTINUOUSLY
-        }
+        // Game uses Canvas renderer by default
 
         audio = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         nchar = Objects.requireNonNull(intent.extras)!!.getInt("nchar")
@@ -130,11 +123,11 @@ class GamePlayActivity : Activity() {
                 or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                 or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
 
-        // Mostrar OpenGL y ocultar el juego normal para la demo
-        binding.openGLSpriteView?.visibility = View.VISIBLE
-        binding.gamePlay?.visibility = View.GONE
-        binding.bgPad?.visibility = View.GONE
-        binding.videoViewBGA?.visibility = View.GONE
+        // Mostrar el juego tradicional
+        binding.openGLSpriteView?.visibility = View.GONE
+        binding.gamePlay?.visibility = View.VISIBLE
+        binding.bgPad?.visibility = View.VISIBLE
+        binding.videoViewBGA?.visibility = View.VISIBLE
 
         //set height  to bga
         startGamePlay()
@@ -142,19 +135,13 @@ class GamePlayActivity : Activity() {
 
     override fun onPause() {
         super.onPause()
-        binding.openGLSpriteView?.onPause()
     }
 
     override fun onResume() {
         super.onResume()
-        binding.openGLSpriteView?.onResume()
     }
 
     private fun startGamePlay() {
-        // Para la demo, solo iniciamos el OpenGL renderer
-        // El código original del juego queda comentado
-
-        /*
         try {
             // gamePlay!!.top = 0
             val rawSSC =
@@ -170,7 +157,6 @@ class GamePlayActivity : Activity() {
                     false
                 )
                 step.path = Objects.requireNonNull(path).toString()
-                //                gpo.build1Object(getBaseContext(), new SSC(z, false), nchar, path, this, pad, Common.WIDTH, Common.HEIGHT);
                 windowManager.defaultDisplay.getRealMetrics(displayMetrics)
                 binding.gamePlay.startGamePLay(
                     binding.videoViewBGA,
@@ -208,30 +194,15 @@ class GamePlayActivity : Activity() {
             true
         }
         if (!gamePlayError && binding.gamePlay != null) binding.gamePlay!!.startGame() else finish()
-        */
-
-        // Simular que el juego está corriendo correctamente
-        gamePlayError = false
-
-        // ... existing code ...
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
-            // Para la demo OpenGL, simplemente finalizamos
-            finish()
-            return true
-        }
-
-        // El resto del código original se mantiene para compatibilidad
-        /*
         if (keyCode == KeyEvent.KEYCODE_BACK) {
             if (!gamePlayError && binding.gamePlay != null) {
                 binding.gamePlay.stop()
             }
             super.onBackPressed()
         }
-        */
 
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_1 -> inputs[7] = 1

--- a/app/src/main/res/layout/activity_test_gl_player.xml
+++ b/app/src/main/res/layout/activity_test_gl_player.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.kyagamy.step.engine.OpenGLSpriteView
+        android:id="@+id/openGLSpriteView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add `ArrowSpriteRenderer` wrapper to load a single texture with `SpriteGLRenderer`
- expose a new `TestGLPlayerActivity` and layout
- wire a button in `StartActivity` to launch the test activity
- register the activity in the manifest
- revert `GamePlayActivity` back to the previous canvas implementation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680c489550832f85ea91672bb00d85