### PR TITLE
Improve SSC parser and note rendering

### DIFF
--- a/app/src/main/java/com/kyagamy/step/common/step/CommonSteps.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/CommonSteps.kt
@@ -3,6 +3,7 @@ package com.kyagamy.step.common.step
 import android.util.Log
 import com.kyagamy.step.common.step.Game.GameRow
 import game.Note
+import game.NoteType
 import java.lang.Exception
 import java.util.*
 import kotlin.collections.ArrayList
@@ -16,18 +17,18 @@ public class CommonSteps {
         const val ARROW_HOLD_PRESSED: Byte = 2
 
         /**NOTE FIELDS*/
-        const val NOTE_EMPTY: Short = 0
-        const val NOTE_TAP: Short = 1
-        const val NOTE_LONG_START: Short = 2
-        const val NOTE_LONG_END: Short = 3
-        const val NOTE_FAKE: Short = 4
-        const val NOTE_MINE: Short = 5
-        const val NOTE_MINE_DEATH: Short = 6
-        const val NOTE_POSION: Short = 7
-        const val NOTE_LONG_BODY: Short = 50
-        const val NOTE_LONG_TOUCHABLE: Short = 10
-        const val NOTE_PRESSED: Short = 128
-        const val NOTE_LONG_PRESSED: Short = 51
+        val NOTE_EMPTY = NoteType.EMPTY
+        val NOTE_TAP = NoteType.TAP
+        val NOTE_LONG_START = NoteType.LONG_START
+        val NOTE_LONG_END = NoteType.LONG_END
+        val NOTE_FAKE = NoteType.FAKE
+        val NOTE_MINE = NoteType.MINE
+        val NOTE_MINE_DEATH = NoteType.MINE_DEATH
+        val NOTE_POSION = NoteType.POSION
+        val NOTE_LONG_BODY = NoteType.LONG_BODY
+        val NOTE_LONG_TOUCHABLE = NoteType.LONG_TOUCHABLE
+        val NOTE_PRESSED = NoteType.PRESSED
+        val NOTE_LONG_PRESSED = NoteType.LONG_PRESSED
 
         /**PERFORMANCE*/
         const val PLAYER_0: Byte = 1
@@ -99,82 +100,6 @@ public class CommonSteps {
         }
 
 
-        fun applyLongNotes(steps: ArrayList<GameRow>, len: Int) {
-            try {
-                var currentTickCount = 2.0
-                var intialTickCount = 2.0
-                var i = 0
-                while (i < steps.size) {
-                    val row = steps[i]
-                    if (row.modifiers?.get("TICKCOUNTS") != null)
-                        intialTickCount = row.modifiers!!["TICKCOUNTS"]!![1]
-                    if (row.notes != null) {
-                        for (j in 0 until row.notes!!.size) {
-                            currentTickCount = intialTickCount + 0.00000001
-                            if (row.notes!![j].type == NOTE_LONG_START) {
-                                val beatLimit = row.notes!![j].rowEnd?.currentBeat
-                                var beatLong = row.currentBeat
-
-                                try {
-                                    while (beatLong <= beatLimit ?: 0.0) {//prevent infinite loop
-                                        beatLong += (1.0 / currentTickCount)//currentTickCount
-                                        val newRowAux =
-                                            steps.firstOrNull { findRow ->//find row correspondent
-                                                almostEqual(
-                                                    beatLong,
-                                                    findRow.currentBeat
-                                                )
-                                            }
-                                        if (newRowAux == null) {//case does't exist row
-                                            val newNote =
-                                                Note.CloneNote(row.notes!![j])//Se crea una nueva nota que tiene los mismos parametros que la de entrada
-                                            newNote.type = NOTE_LONG_BODY
-                                            newNote.rowOrigin = row
-                                            val newRow = GameRow()
-                                            newRow.currentBeat = beatLong
-                                            newRow.notes = arrayListOf(Note())
-                                            for (cc in 0..len - 2)
-                                                newRow.notes!!.add(Note())
-                                            newRow.notes!![j] = newNote
-                                            newRow.notes!![j].type = NOTE_LONG_BODY
-                                            newRow.notes!![j].rowOrigin = row
-                                            newRow.notes!![j].rowEnd = row.notes!![j].rowEnd
-
-                                            steps.add(newRow)
-                                        } else {//exist row
-                                            if (newRowAux.modifiers?.get("TICKCOUNTS") != null) {
-                                                currentTickCount =
-                                                    newRowAux.modifiers!!["TICKCOUNTS"]!![1]
-                                            }
-                                            if (newRowAux.notes != null && newRowAux.notes?.get(j)!!.type == NOTE_LONG_END) {
-                                                newRowAux.notes!![j].rowOrigin = row
-                                                break
-                                            }
-                                            if (newRowAux.notes == null) {
-                                                newRowAux.notes = arrayListOf(Note())
-                                                for (cc in 0..len - 2)
-                                                    newRowAux.notes!!.add(Note())
-                                            }
-                                            if (newRowAux.notes!![j].type != NOTE_LONG_END) {
-                                                newRowAux.notes!![j].type = NOTE_LONG_BODY
-                                            }
-                                            newRowAux.notes!![j].rowOrigin = row
-                                            newRowAux.notes!![j].rowEnd = row.notes!![j].rowEnd
-                                        }
-                                    }
-                                } catch (ex: Exception) {
-                                    ex.stackTrace
-                                }
-                            }
-                        }
-                    }
-                    i++
-                }
-            } catch (ex: Exception) {
-                ex.stackTrace
-                Log.d("Parse error ", "Failed proces long notes")
-            }
-        }
 
         fun stopsToScroll(steps: ArrayList<GameRow>) {
             var rowaux = GameRow();

--- a/app/src/main/java/com/kyagamy/step/common/step/Game/Note.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/Game/Note.kt
@@ -4,7 +4,7 @@ import com.kyagamy.step.common.step.Game.GameRow
 
 
 class Note {
-    var type: Short = 0
+    var type: NoteType = NoteType.EMPTY
     var player: Byte = 0
     var skin: Byte = 0
     var sudden: Boolean = false

--- a/app/src/main/java/com/kyagamy/step/common/step/Game/NoteType.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/Game/NoteType.kt
@@ -1,0 +1,16 @@
+package game
+
+enum class NoteType(val code: Short) {
+    EMPTY(0),
+    TAP(1),
+    LONG_START(2),
+    LONG_END(3),
+    FAKE(4),
+    MINE(5),
+    MINE_DEATH(6),
+    POSION(7),
+    LONG_BODY(50),
+    LONG_TOUCHABLE(10),
+    PRESSED(128),
+    LONG_PRESSED(51)
+}

--- a/app/src/main/java/com/kyagamy/step/engine/NoteLayoutCalculator.kt
+++ b/app/src/main/java/com/kyagamy/step/engine/NoteLayoutCalculator.kt
@@ -1,0 +1,61 @@
+package com.kyagamy.step.engine
+
+import android.graphics.Point
+
+class NoteLayoutCalculator {
+    data class Layout(
+        val sizeX: Int,
+        val sizeY: Int,
+        val sizeNote: Int,
+        val scaledNoteSize: Int,
+        val offsetX: Int,
+        val offsetY: Int,
+        val posInitialX: Int,
+        val startValueY: Int
+    )
+
+    companion object {
+        private const val STEPS_Y_COUNT = 9.3913f
+        private const val RECEPTOR_Y_FACTOR = 0.7f
+        private const val NOTE_SCALE_FACTOR = 1.245f
+        private const val ASPECT_RATIO_16_9_CALC = 1.77777778f
+
+        fun calculate(gameMode: StepsDrawerGL.GameMode, aspectRatio: String, landScape: Boolean, screenSize: Point): Layout {
+            var sizeX: Int
+            var sizeY: Int
+            var offsetX = 0
+            var offsetY = 0
+
+            if (landScape) {
+                sizeY = screenSize.y
+                sizeX = (screenSize.y * ASPECT_RATIO_16_9_CALC).toInt()
+                offsetX = ((screenSize.x - sizeX) / 2f).toInt()
+
+                if (sizeX > screenSize.x) {
+                    sizeY = (screenSize.x / ASPECT_RATIO_16_9_CALC).toInt()
+                    sizeX = (sizeY * ASPECT_RATIO_16_9_CALC).toInt()
+                    offsetX = kotlin.math.abs(((screenSize.x - sizeX) / 2f).toInt())
+                    offsetY = ((screenSize.y - sizeY) / 2f).toInt()
+                }
+
+                sizeX += offsetX / 2
+                sizeY += offsetY
+            } else {
+                sizeY = screenSize.y / 2
+                sizeX = screenSize.x
+
+                if ((sizeY / STEPS_Y_COUNT).toInt() * gameMode.steps > sizeX) {
+                    sizeY = (sizeX / (gameMode.steps + 0.2) * STEPS_Y_COUNT).toInt()
+                    offsetY = screenSize.y - sizeY
+                }
+            }
+
+            val sizeNote = (sizeY / STEPS_Y_COUNT).toInt()
+            val scaledNoteSize = (sizeNote * NOTE_SCALE_FACTOR).toInt()
+            val posInitialX = (((sizeX) - (sizeNote * gameMode.steps))) / 2 + offsetX / 2
+            val startValueY = (sizeNote * RECEPTOR_Y_FACTOR).toInt()
+
+            return Layout(sizeX, sizeY, sizeNote, scaledNoteSize, offsetX, offsetY, posInitialX, startValueY)
+        }
+    }
+}

--- a/app/src/test/java/com/kyagamy/step/FileSSCParserTest.kt
+++ b/app/src/test/java/com/kyagamy/step/FileSSCParserTest.kt
@@ -1,0 +1,51 @@
+package com.kyagamy.step
+
+import com.kyagamy.step.common.step.Parsers.FileSSC
+import game.NoteType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileSSCParserTest {
+    @Test
+    fun parseSimpleHold_shouldLinkStartAndEnd() {
+        val data = """
+            #NOTEDATA:;
+            #STEPSTYPE:pump-single;
+            #NOTES:
+            2000
+            0000
+            3000
+            0000
+            ;
+        """.trimIndent()
+        val parser = FileSSC(data, 0)
+        val stepObj = parser.parseData(false)
+        val rows = stepObj.steps
+        val startNote = rows[0].notes!![0]
+        val endNote = rows[2].notes!![0]
+        assertEquals(NoteType.LONG_START, startNote.type)
+        assertEquals(rows[2], startNote.rowEnd)
+        assertEquals(rows[0], endNote.rowOrigin)
+    }
+}
+
+    @Test
+    fun parseSimpleHold_hasCorrectBeats() {
+        val data = """
+            #NOTEDATA:;
+            #STEPSTYPE:pump-single;
+            #NOTES:
+            2000
+            0000
+            3000
+            0000
+            ;
+        """.trimIndent()
+        val parser = FileSSC(data, 0)
+        val stepObj = parser.parseData(false)
+        val rows = stepObj.steps
+        assertEquals(0.0, rows[0].currentBeat, 0.0)
+        assertEquals(1.0, rows[1].currentBeat, 0.0)
+        assertEquals(2.0, rows[2].currentBeat, 0.0)
+    }
+}

--- a/docs/note_flow.puml
+++ b/docs/note_flow.puml
@@ -1,0 +1,7 @@
+@startuml
+class FileSSC
+class NoteLayoutCalculator
+class StepsDrawerGL
+FileSSC --> StepsDrawerGL : produces GameRows
+StepsDrawerGL --> NoteLayoutCalculator : uses layout
+@enduml


### PR DESCRIPTION
## Summary
- replace note type constants with `NoteType` enum
- track long notes in parser with map and link rows directly
- remove obsolete long note post-processing
- extract layout logic into `NoteLayoutCalculator`
- refactor GL drawer to new layout helper and segmented long note drawing
- filter sprites outside viewport
- add unit tests for parsing
- document flow with a UML diagram

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7c1b6e4832f9a7bb5bc5dfcc8ae