### PR TITLE
Improve SSC parser and long note handling

### DIFF
--- a/app/src/main/java/com/kyagamy/step/common/step/Game/Note.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/Game/Note.kt
@@ -4,7 +4,13 @@ import com.kyagamy.step.common.step.Game.GameRow
 
 
 class Note {
-    var type: Short = 0
+    var noteType: NoteType = NoteType.EMPTY
+    @Deprecated("Use noteType", ReplaceWith("noteType.code"))
+    var type: Short
+        get() = noteType.code
+        set(value) {
+            noteType = NoteType.fromCode(value)
+        }
     var player: Byte = 0
     var skin: Byte = 0
     var sudden: Boolean = false
@@ -19,8 +25,8 @@ class Note {
     companion object {
         fun CloneNote(baseNote: Note): Note {
             val newNote = Note()
-            newNote.rowOrigin=baseNote.rowOrigin
-            newNote.rowEnd=baseNote.rowEnd
+            newNote.rowOrigin = baseNote.rowOrigin
+            newNote.rowEnd = baseNote.rowEnd
 
             newNote.fake = baseNote.fake
             newNote.vanish = baseNote.vanish
@@ -28,7 +34,7 @@ class Note {
             newNote.skin = baseNote.skin
             newNote.player = baseNote.player
             newNote.sudden = baseNote.sudden
-            newNote.type = baseNote.type
+            newNote.noteType = baseNote.noteType
             return newNote
         }
     }

--- a/app/src/main/java/com/kyagamy/step/common/step/Game/NoteType.kt
+++ b/app/src/main/java/com/kyagamy/step/common/step/Game/NoteType.kt
@@ -1,0 +1,22 @@
+package game
+
+enum class NoteType(val code: Short) {
+    EMPTY(0),
+    TAP(1),
+    LONG_START(2),
+    LONG_END(3),
+    FAKE(4),
+    MINE(5),
+    MINE_DEATH(6),
+    POSION(7),
+    LONG_BODY(50),
+    LONG_TOUCHABLE(10),
+    PRESSED(128),
+    LONG_PRESSED(51);
+
+    companion object {
+        fun fromCode(code: Short): NoteType {
+            return entries.find { it.code == code } ?: EMPTY
+        }
+    }
+}

--- a/app/src/main/java/com/kyagamy/step/engine/NoteLayoutCalculator.kt
+++ b/app/src/main/java/com/kyagamy/step/engine/NoteLayoutCalculator.kt
@@ -1,0 +1,76 @@
+package com.kyagamy.step.engine
+
+import android.graphics.Point
+import kotlin.math.abs
+
+class NoteLayoutCalculator {
+    data class Layout(
+        val sizeX: Int,
+        val sizeY: Int,
+        val sizeNote: Int,
+        val scaledNoteSize: Int,
+        val offsetX: Int,
+        val offsetY: Int,
+        val posInitialX: Int,
+        val startValueY: Int
+    )
+
+    companion object {
+        private const val STEPS_Y_COUNT = 9.3913f
+        private const val RECEPTOR_Y_FACTOR = 0.7f
+        private const val NOTE_SCALE_FACTOR = 1.245f
+        private const val ASPECT_RATIO_16_9_CALC = 1.77777778f
+
+        fun calculate(
+            gameMode: StepsDrawerGL.GameMode,
+            aspectRatio: String,
+            landScape: Boolean,
+            screenSize: Point
+        ): Layout {
+            var sizeX: Int
+            var sizeY: Int
+            var offsetX = 0
+            var offsetY = 0
+
+            if (landScape) {
+                sizeY = screenSize.y
+                sizeX = (screenSize.y * ASPECT_RATIO_16_9_CALC).toInt()
+                offsetX = ((screenSize.x - sizeX) / 2f).toInt()
+
+                if (sizeX > screenSize.x) {
+                    sizeY = (screenSize.x / ASPECT_RATIO_16_9_CALC).toInt()
+                    sizeX = (sizeY * ASPECT_RATIO_16_9_CALC).toInt()
+                    offsetX = abs(((screenSize.x - sizeX) / 2f).toInt())
+                    offsetY = ((screenSize.y - sizeY) / 2f).toInt()
+                }
+
+                sizeX += offsetX / 2
+                sizeY += offsetY
+            } else {
+                sizeY = screenSize.y / 2
+                sizeX = screenSize.x
+
+                if ((sizeY / STEPS_Y_COUNT).toInt() * gameMode.steps > sizeX) {
+                    sizeY = (sizeX / (gameMode.steps + 0.2) * STEPS_Y_COUNT).toInt()
+                    offsetY = screenSize.y - sizeY
+                }
+            }
+
+            val sizeNote = (sizeY / STEPS_Y_COUNT).toInt()
+            val scaledNoteSize = (sizeNote * NOTE_SCALE_FACTOR).toInt()
+            val posInitialX = (((sizeX) - (sizeNote * gameMode.steps))) / 2 + offsetX / 2
+            val startValueY = (sizeNote * RECEPTOR_Y_FACTOR).toInt()
+
+            return Layout(
+                sizeX,
+                sizeY,
+                sizeNote,
+                scaledNoteSize,
+                offsetX,
+                offsetY,
+                posInitialX,
+                startValueY
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/kyagamy/step/NoteLayoutCalculatorTest.kt
+++ b/app/src/test/java/com/kyagamy/step/NoteLayoutCalculatorTest.kt
@@ -1,0 +1,23 @@
+package com.kyagamy.step
+
+import android.graphics.Point
+import com.kyagamy.step.engine.NoteLayoutCalculator
+import com.kyagamy.step.engine.StepsDrawerGL
+import org.junit.Assert.*
+import org.junit.Test
+
+class NoteLayoutCalculatorTest {
+    @Test
+    fun layout_basic_values() {
+        val screen = Point(1080, 1920)
+        val layout = NoteLayoutCalculator.calculate(
+            StepsDrawerGL.GameMode.PUMP_SINGLE,
+            "16:9",
+            true,
+            screen
+        )
+        assertTrue(layout.sizeX > 0)
+        assertTrue(layout.sizeY > 0)
+        assertTrue(layout.scaledNoteSize > layout.sizeNote)
+    }
+}

--- a/app/src/test/java/com/kyagamy/step/ParserLongNoteTest.kt
+++ b/app/src/test/java/com/kyagamy/step/ParserLongNoteTest.kt
@@ -1,0 +1,24 @@
+package com.kyagamy.step
+
+import com.kyagamy.step.common.step.Parsers.FileSSC
+import game.NoteType
+import org.junit.Assert.*
+import org.junit.Test
+
+class ParserLongNoteTest {
+    @Test
+    fun parse_long_note_links() {
+        val data = """#NOTEDATA:;\n#STEPSTYPE:pump-single;\n#NOTES:\n0000\n2000\n0000\n3000\n;"""
+        val parser = FileSSC(data, 0)
+        val stepObject = parser.parseData(false)
+        val steps = stepObject.steps
+        val startRow = steps.first { row -> row.notes?.any { it.noteType == NoteType.LONG_START } == true }
+        val endRow = steps.first { row -> row.notes?.any { it.noteType == NoteType.LONG_END } == true }
+        val startNote = startRow.notes!!.first { it.noteType == NoteType.LONG_START }
+        val endNote = endRow.notes!!.first { it.noteType == NoteType.LONG_END }
+        assertSame(startRow, endNote.rowOrigin)
+        assertSame(endRow, startNote.rowEnd)
+        assertEquals(1.0, startRow.currentBeat, 0.0001)
+        assertEquals(3.0, endRow.currentBeat, 0.0001)
+    }
+}

--- a/docs/ssc_parser_flow.md
+++ b/docs/ssc_parser_flow.md
@@ -1,0 +1,18 @@
+# SSC Parser Flow
+
+```plantuml
+@startuml
+class FileSSC
+class NoteLayoutCalculator
+class StepsDrawerGL
+class GameRow
+class Note
+class NoteType
+FileSSC --> GameRow
+GameRow --> Note
+Note --> NoteType
+FileSSC --> NoteLayoutCalculator
+StepsDrawerGL --> NoteLayoutCalculator
+StepsDrawerGL --> Note
+@enduml
+```


### PR DESCRIPTION
## Summary
- add `NoteType` enum and migrate Note class
- track long note start/end using a map
- drop `applyLongNotes` post-processing
- draw long notes using new helpers in `StepsDrawerGL`
- extract layout sizing into `NoteLayoutCalculator`
- document new flow with UML diagram
- add basic parser and layout tests

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7c1b6e4832f9a7bb5bc5dfcc8ae